### PR TITLE
force python3-Pygments installation

### DIFF
--- a/org.qutebrowser.qutebrowser.yml
+++ b/org.qutebrowser.qutebrowser.yml
@@ -36,6 +36,9 @@ modules:
 
   - python3-Jinja2.json
   - python3-PyYAML.json
+  # pygments is an optional dependecy. with the webengine backend is only used
+  #   when viewing source with ':view-source --pygments'
+  - python3-Pygments.json
   - python3-toml.json
   - python3-typing-extensions.json
 

--- a/python3-Pygments.json
+++ b/python3-Pygments.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-Pygments",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --ignore-installed --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"Pygments==2.8.1\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/15/9d/bc9047ca1eee944cc245f3649feea6eecde3f38011ee9b8a6a64fb7088cd/Pygments-2.8.1.tar.gz",
+            "sha256": "2656e1a6edcdabf4275f9a3640db59fd5de107d88e8663c5d4e9a0fa62f77f94"
+        }
+    ]
+}


### PR DESCRIPTION
Pygments is available in the 5.15 kde sdk but not the plaform runtime so
it's not being installed during build-time and it's missing during
runtime.
This workaround uses the `pip install` option `--ignore-installed` to
force-install the module into `$FLATPAK_DEST` without ending with an
after pip tries to make changes to the read-only `/usr`.