### PR TITLE
Build our own QtWebEngine lib

### DIFF
--- a/org.qutebrowser.qutebrowser.yml
+++ b/org.qutebrowser.qutebrowser.yml
@@ -4,6 +4,7 @@ runtime-version: '5.15'
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable
+  - org.freedesktop.Sdk.Extension.node14
 add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg
@@ -12,8 +13,8 @@ add-extensions:
     no-autodownload: true
 command: qutebrowser
 rename-icon: qutebrowser
-base: io.qt.qtwebengine.BaseApp
-base-version: '5.15'
+#base: io.qt.qtwebengine.BaseApp
+#base-version: '5.15'
 finish-args:
   - --device=dri
   - --env=QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess
@@ -21,6 +22,7 @@ finish-args:
   - --filesystem=xdg-music
   - --filesystem=xdg-pictures
   - --filesystem=xdg-videos
+  - --filesystem=xdg-run/pipewire-0:ro
   - --own-name=org.kde.*
   - --own-name=org.mpris.MediaPlayer2.qutebrowser.*
   - --share=ipc
@@ -33,13 +35,18 @@ finish-args:
   - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.kde.StatusNotifierWatcher
-cleanup-commands:
-  - /app/cleanup-BaseApp.sh
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - '*.a'
+  - '*.la'
+#cleanup-commands:
+#  - /app/cleanup-BaseApp.sh
 modules:
   - name: qutebrowser
     buildsystem: simple
     build-commands:
-      - python scripts/asciidoc2html.py
+      - python3 scripts/asciidoc2html.py
       - make --file misc/Makefile install PREFIX=/app
       - mkdir -p /app/lib/ffmpeg
     run-tests: false
@@ -70,9 +77,6 @@ modules:
           - type: archive
             url: https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz
             sha256: c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4
-        cleanup:
-          - '*.a'
-          - '*.la'
 # TODO: add here pyperclip backends?
 # TODO: add here dependencies of pykeepass
       # generated with flatpak-pip-generator from requirements.txt
@@ -153,9 +157,8 @@ modules:
               - processed=`sed -e 's|prefix|sysroot|' <<< $@`
               - python3 configure.py $processed
             dest-filename: configure
-        cleanup:
-          - /lib/debug
         modules:
+          - qt5-webengine.json
           - name: pyqt5
             config-opts:
               - --assume-shared
@@ -197,7 +200,6 @@ modules:
                 - python3 configure.py $processed
                 dest-filename: configure
             cleanup:
-              - /lib/debug
               - /share/sip
             modules:
               - name: sip
@@ -221,7 +223,6 @@ modules:
                     dest-filename: configure
                 cleanup:
                   - /bin
-                  - /include
       - name: pdfjs
         buildsystem: simple
         build-commands:
@@ -245,6 +246,4 @@ modules:
           - type: archive
             url: https://gitlab.gnome.org/GNOME/libsecret/-/archive/0.20.4/libsecret-0.20.4.tar.gz
             sha256: ca34e69b210df221ae5da6692c2cb15ef169bb4daf42e204442f24fdb0520d4b
-        cleanup:
-          - /include
 #     - tests-dependencies.json

--- a/qt5-webengine-locales.patch
+++ b/qt5-webengine-locales.patch
@@ -1,0 +1,13 @@
+diff --git a/src/core/web_engine_library_info.cpp b/src/core/web_engine_library_info.cpp
+index 3a649227..56d31e46 100644
+--- a/src/core/web_engine_library_info.cpp
++++ b/src/core/web_engine_library_info.cpp
+@@ -205,7 +205,7 @@ QString localesPath()
+ #if defined(OS_MAC) && defined(QT_MAC_FRAMEWORK_BUILD)
+             getResourcesPath(frameworkBundle()) % QLatin1String("/qtwebengine_locales");
+ #else
+-            QLibraryInfo::location(QLibraryInfo::TranslationsPath) % QDir::separator() % QLatin1String("qtwebengine_locales");
++            "/app/translations/qtwebengine_locales";
+ #endif
+ 
+     if (!initialized) {

--- a/qt5-webengine-resources.patch
+++ b/qt5-webengine-resources.patch
@@ -1,0 +1,13 @@
+diff --git a/src/core/web_engine_library_info.cpp b/src/core/web_engine_library_info.cpp
+index 56d31e46..28db02f6 100644
+--- a/src/core/web_engine_library_info.cpp
++++ b/src/core/web_engine_library_info.cpp
+@@ -280,7 +280,7 @@ QString resourcesDataPath()
+ #elif defined(OS_MAC)
+             QLibraryInfo::location(QLibraryInfo::DataPath) % QLatin1String("/Resources");
+ #else
+-            QLibraryInfo::location(QLibraryInfo::DataPath) % QLatin1String("/resources");
++            QLatin1String("/app/resources");
+ #endif
+     if (!initialized) {
+         initialized = true;

--- a/qt5-webengine.json
+++ b/qt5-webengine.json
@@ -1,0 +1,139 @@
+{
+  "name": "qt5-webengine",
+  "buildsystem": "qmake",
+  "build-options": {
+    "append-path": "/usr/lib/sdk/node14/bin",
+    "env": [
+      "npm_config_nodedir=/usr/lib/sdk/node14"
+    ]
+  },
+  "make-install-args": [
+    "INSTALL_ROOT=/app/scratchdir"
+  ],
+  "config-opts": [
+    "--",
+    "-system-ffmpeg",
+    "-webengine-icu",
+    "-webengine-proprietary-codecs",
+    "-webengine-webrtc-pipewire",
+    "-webp"
+  ],
+  "post-install": [
+    "cp -r /app/scratchdir/usr/* /app",
+    "rm -rf /app/scratchdir",
+    "ln -s /app/lib/*/*.so* /app/lib",
+    "sed -e 's@PATHS \"${CMAKE_CURRENT_LIST_DIR}/..\" NO_DEFAULT_PATH@PATHS \"${CMAKE_CURRENT_LIST_DIR}/..\" \"/usr/lib/${CMAKE_CXX_LIBRARY_ARCHITECTURE}/cmake/\" NO_DEFAULT_PATH@' -i /app/lib/*/cmake/*/*Config.cmake",
+    "sed -e 's@$$QT_MODULE_LIB_BASE@/app/lib@' -i /app/lib/mkspecs/modules/*.pri",
+    "mv /app/lib/libexec/QtWebEngineProcess -t /app/bin"
+  ],
+  "sources": [
+    {
+      "type": "git",
+      "url": "https://invent.kde.org/qt/qt/qtwebengine.git",
+      "tag": "v5.15.5-lts",
+      "commit": "9711f64c5082040cb76f6da5ef4a16037dbda08f"
+    },
+    {
+      "type": "patch",
+      "path": "qt5-webengine-locales.patch"
+    },
+    {
+      "type": "patch",
+      "path": "qt5-webengine-resources.patch"
+    }
+  ],
+  "cleanup": [
+    "/bin/qwebengine_convert_dict",
+    "/lib/mkspecs",
+    "/lib/plugins/designer",
+    "*.prl",
+    "*.cmake",
+    "*.pc"
+  ],
+  "modules": [
+    {
+      "name": "python2",
+      "cleanup": [
+        "*"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tar.xz",
+          "sha256": "b62c0e7937551d0cc02b8fd5cb0f544f9405bafc9a54d3808ed4594812edef43"
+        }
+      ]
+    },
+    {
+      "name": "pciutils",
+      "no-autogen": true,
+      "make-args": [
+        "SHARED=no",
+        "ZLIB=no",
+        "PREFIX=/app"
+      ],
+      "post-install": [
+        "make install-pcilib",
+        "make install-lib"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://mj.ucw.cz/download/linux/pci/pciutils-3.7.0.tar.gz",
+          "sha256": "08c27e01030d1fcc700d02bc2ea66c638f58a3d150e45e58852aa82ad4160d84"
+        },
+        {
+          "type": "shell",
+          "commands": [
+            "sed -i 's@PREFIX=/usr/local@PREFIX=/app@' Makefile"
+          ]
+        }
+      ],
+      "cleanup": [
+        "/sbin",
+        "/share/pci.ids",
+        "/share/man"
+      ]
+    },
+    {
+      "name": "pipewire-0.2",
+      "buildsystem": "meson",
+      "config-opts": [
+        "-D docs=false",
+        "-D gstreamer=disabled",
+        "-D man=false",
+        "-D systemd=false"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/PipeWire/pipewire/archive/0.2.7.tar.gz",
+          "sha256": "bfaa0f6ae6c0791e2e0b59234d399753bf24f1b33dbf587682363a8463dd8df1"
+        }
+      ],
+      "cleanup": [
+        "/bin",
+        "/etc",
+        "/lib/gstreamer-1.0",
+        "/lib/pipewire-0.2/libpipewire-module-audio-dsp.so",
+        "/lib/pipewire-0.2/libpipewire-module-autolink.so",
+        "/lib/pipewire-0.2/libpipewire-module-link-factory.so",
+        "/lib/pipewire-0.2/libpipewire-module-mixer.so",
+        "/lib/pipewire-0.2/libpipewire-module-portal.so",
+        "/lib/pipewire-0.2/libpipewire-module-rtkit.so",
+        "/lib/pipewire-0.2/libpipewire-module-spa-monitor.so",
+        "/lib/pipewire-0.2/libpipewire-module-spa-node-factory.so",
+        "/lib/pipewire-0.2/libpipewire-module-spa-node.so",
+        "/lib/pipewire-0.2/libpipewire-module-suspend-on-idle.so",
+        "/lib/spa/alsa",
+        "/lib/spa/audiomixer",
+        "/lib/spa/audiotestsrc",
+        "/lib/spa/ffmpeg",
+        "/lib/spa/test",
+        "/lib/spa/v4l2",
+        "/lib/spa/videotestsrc",
+        "/lib/spa/volume"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I'm not really thrilled about this but it's better than shipping a
browser with multiple security vulnerabilities.
I was hoping to get a more prompt response from the QtWebEngine
maintainer in flathub/io.qt.qtwebengine.BaseApp#15 but this doesn't
seem to be happening.

I should stress that this is a stop gap until the QtWebEngine base app
will be updated. I have no desire to keep it like this as I'm not able
nor I'm willing to build Chromium locally.

For quickly building locally and testing packaging changes just revert or
uncomment the base app related properties and comment out the qt5-webengine
module.