### PR TITLE
Add f-e-d-c support

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "automerge-flathubbot-prs": false
+}

--- a/org.qutebrowser.qutebrowser.yml
+++ b/org.qutebrowser.qutebrowser.yml
@@ -59,9 +59,16 @@ modules:
     sources:
       - type: git
         url: https://github.com/qutebrowser/qutebrowser.git
-        #branch: v2.1.x
         tag: v2.2.3
         commit: f35f56ecaa6950bb7a384e328d5852d7dbce1984
+        # python-dependencies are also updated manually on qutebrowser version bump,
+        #   so disable this until we can update them automatically and to avoid conflicting with the bot
+        #x-checker-data:
+        #  type: json
+        #  url: https://api.github.com/repos/qutebrowser/qutebrowser/releases/latest
+        #  tag-query: '.tag_name'
+        #  version-query: '$tag'
+        #  timestamp-query: '.published_at'
       - type: patch
         path: 0001-Remove-manpage-support.patch
     modules:
@@ -70,6 +77,13 @@ modules:
           - type: archive
             url: https://github.com/asciidoc-py/asciidoc-py/releases/download/9.1.0/asciidoc-9.1.0.tar.gz
             sha256: fd499fcf51317b1aaf27336fb5e919c44c1f867f1ae6681ee197365d3065238b
+            x-checker-data:
+              # anitya actually wrong here and marking pre-releases as stable but since the url template only
+              #  correct for stable then it's not an issue.
+              type: anitya
+              project-id: 13262
+              stable-only: true
+              url-template: https://github.com/asciidoc-py/asciidoc-py/releases/download/$version/asciidoc-$version.tar.gz
         cleanup:
           - '*'
       - name: libyaml
@@ -77,9 +91,15 @@ modules:
           - type: archive
             url: https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz
             sha256: c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4
+            x-checker-data:
+              type: anitya
+              project-id: 1800
+              stable-only: true
+              url-template: https://github.com/yaml/libyaml/releases/download/$version/yaml-$version.tar.gz
 # TODO: add here pyperclip backends?
 # TODO: add here dependencies of pykeepass
       # generated with flatpak-pip-generator from requirements.txt
+      # TODO: f-e-d-c?
       - python-dependencies.json
       # pygments is an optional dependecy. with the webengine backend is only used
       #   when viewing source with ':view-source --pygments'
@@ -92,6 +112,9 @@ modules:
           - type: file
             url: https://files.pythonhosted.org/packages/15/9d/bc9047ca1eee944cc245f3649feea6eecde3f38011ee9b8a6a64fb7088cd/Pygments-2.8.1.tar.gz
             sha256: 2656e1a6edcdabf4275f9a3640db59fd5de107d88e8663c5d4e9a0fa62f77f94
+            x-checker-data:
+              type: pypi
+              name: Pygments
       - name: python-adblock
         build-options:
           env:
@@ -109,6 +132,13 @@ modules:
             url: https://github.com/ArniDagur/python-adblock.git
             tag: '0.5.0'
             commit: 06f0782a460edb4dec786842a9f52b9429a4d7e8
+            # disabled as it doesn't update cargo-sources.json
+#           x-checker-data:
+#             type: json
+#             url: https://api.github.com/repos/ArniDagur/python-adblock/releases/latest
+#             tag-query: '.tag_name'
+#             version-query: '$tag'
+#             timestamp-query: '.published_at'
           - python-adblock-cargo-sources.json
         modules:
           - name: maturin
@@ -126,10 +156,17 @@ modules:
               - install -Dm755 target/release/maturin -t /app/bin/
               - install -Dm644 maturin/__init__.py -t /app/lib/python3.8/site-packages/maturin/
             sources:
-              - maturin-cargo-sources.json
               - type: archive
                 url: https://github.com/PyO3/maturin/archive/v0.10.6.tar.gz
                 sha256: e6a9a67cc62ffe248654e60e7ec211bf23319c4c936ad87022f7a1fd0997430d
+                # disabled as it doesn't update cargo-sources.json
+#               x-checker-data:
+#                 type: json
+#                 url: https://api.github.com/repos/PyO3/maturin/releases/latest
+#                 tag-query: '.tag_name'
+#                 version-query: '$tag'
+#                 timestamp-query: '.published_at'
+              - maturin-cargo-sources.json
             cleanup:
               - '*'
       - name: pyqt5-webengine
@@ -152,6 +189,9 @@ modules:
           - type: archive
             url: https://pypi.python.org/packages/source/P/PyQtWebEngine/PyQtWebEngine-5.15.4.tar.gz
             sha256: cedc28f54165f4b8067652145aec7f732a17eadf6736835852868cf76119cc19
+            x-checker-data:
+              type: pypi
+              name: PyQtWebEngine
           - type: script
             commands:
               - processed=`sed -e 's|prefix|sysroot|' <<< $@`
@@ -194,6 +234,9 @@ modules:
               - type: archive
                 url: https://pypi.python.org/packages/source/P/PyQt5/PyQt5-5.15.4.tar.gz
                 sha256: 2a69597e0dd11caabe75fae133feca66387819fc9bc050f547e5551bce97e5be
+                x-checker-data:
+                  type: pypi
+                  name: PyQt5
               - type: script
                 commands:
                 - processed=`sed -e 's|prefix|sysroot|' <<< $@`
@@ -216,6 +259,10 @@ modules:
                   - type: archive
                     url: https://www.riverbankcomputing.com/static/Downloads/sip/4.19.25/sip-4.19.25.tar.gz
                     sha256: b39d93e937647807bac23579edbff25fe46d16213f708370072574ab1f1b4211
+                    # TODO: switch to sip6 and enable this
+                    #x-checker-data:
+                    #  type: pypi
+                    #  name: sip
                   - type: script
                     commands:
                       - processed=`sed -e 's|--prefix=/app||' <<< $@`
@@ -234,6 +281,11 @@ modules:
           - type: file
             url: https://github.com/mozilla/pdf.js/releases/download/v2.9.359/pdfjs-2.9.359-dist.zip
             sha256: b053fe9f4e467495b02909a078b055cf708de4ebffcfd8d6e7a348e711714958
+            x-checker-data:
+              type: json
+              url: https://api.github.com/repos/mozilla/pdf.js/releases
+              version-query: '.[0] | .tag_name | sub("^v"; "")'
+              url-query: '.[0] | .assets[] | select(.name=="pdfjs-" + $version + "-dist.zip") | .browser_download_url'
       # userscripts/password_fill secret backend
       - name: libsecret
         buildsystem: meson
@@ -246,4 +298,9 @@ modules:
           - type: archive
             url: https://gitlab.gnome.org/GNOME/libsecret/-/archive/0.20.4/libsecret-0.20.4.tar.gz
             sha256: ca34e69b210df221ae5da6692c2cb15ef169bb4daf42e204442f24fdb0520d4b
+            x-checker-data:
+              type: anitya
+              project-id: 13150
+              url-template: https://gitlab.gnome.org/GNOME/libsecret/-/archive/$version/libsecret-$version.tar.gz
+      # TODO: f-e-d-c?
 #     - tests-dependencies.json

--- a/python-dependencies.json
+++ b/python-dependencies.json
@@ -35,7 +35,7 @@
             "name": "python3-colorama",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"colorama==0.4.4\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"colorama\" --no-build-isolation"
             ],
             "sources": [
                 {
@@ -49,13 +49,18 @@
             "name": "python3-importlib-resources",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"importlib-resources==5.1.2\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"importlib-resources\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/c8/b2/d8263caf10de8632ef6756991d52e7fb0d8f5aa1e473344fad79b19ccb23/importlib_resources-5.1.2.tar.gz",
-                    "sha256": "642586fc4740bd1cad7690f836b3321309402b20b332529f25617ff18e8e1370"
+                    "url": "https://files.pythonhosted.org/packages/38/f9/4fa6df2753ded1bcc1ce2fdd8046f78bd240ff7647f5c9bcf547c0df77e3/zipp-3.4.1.tar.gz",
+                    "sha256": "3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/7e/6c/2077c481c94e7a75e0678a41cb4e2a7916ac215e7a7677c5839513122d24/importlib_resources-5.1.4.tar.gz",
+                    "sha256": "54161657e8ffc76596c4ede7080ca68cb02962a2e074a2586b695a93a925d36e"
                 }
             ]
         },
@@ -63,18 +68,18 @@
             "name": "python3-Jinja2",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"Jinja2==2.11.3\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"Jinja2\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/b9/2e/64db92e53b86efccfaea71321f597fa2e1b2bd3853d8ce658568f7a13094/MarkupSafe-1.1.1.tar.gz",
-                    "sha256": "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"
+                    "url": "https://files.pythonhosted.org/packages/bf/10/ff66fea6d1788c458663a84d88787bae15d45daa16f6b3ef33322a51fc7e/MarkupSafe-2.0.1.tar.gz",
+                    "sha256": "594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/4f/e7/65300e6b32e69768ded990494809106f87da1d436418d5f1367ed3966fd7/Jinja2-2.11.3.tar.gz",
-                    "sha256": "a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"
+                    "url": "https://files.pythonhosted.org/packages/39/11/8076571afd97303dfeb6e466f27187ca4970918d4b36d5326725514d3ed3/Jinja2-3.0.1.tar.gz",
+                    "sha256": "703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4"
                 }
             ]
         },
@@ -82,13 +87,13 @@
             "name": "python3-MarkupSafe",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"MarkupSafe==1.1.1\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"MarkupSafe\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/b9/2e/64db92e53b86efccfaea71321f597fa2e1b2bd3853d8ce658568f7a13094/MarkupSafe-1.1.1.tar.gz",
-                    "sha256": "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"
+                    "url": "https://files.pythonhosted.org/packages/bf/10/ff66fea6d1788c458663a84d88787bae15d45daa16f6b3ef33322a51fc7e/MarkupSafe-2.0.1.tar.gz",
+                    "sha256": "594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"
                 }
             ]
         },
@@ -96,7 +101,7 @@
             "name": "python3-PyYAML",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"PyYAML==5.4.1\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"PyYAML\" --no-build-isolation"
             ],
             "sources": [
                 {
@@ -110,13 +115,13 @@
             "name": "python3-typing-extensions",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"typing-extensions==3.7.4.3\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"typing-extensions\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/16/06/0f7367eafb692f73158e5c5cbca1aec798cdf78be5167f6415dd4205fa32/typing_extensions-3.7.4.3.tar.gz",
-                    "sha256": "99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"
+                    "url": "https://files.pythonhosted.org/packages/aa/55/62e2d4934c282a60b4243a950c9dbfa01ae7cac0e8d6c0b5315b87432c81/typing_extensions-3.10.0.0.tar.gz",
+                    "sha256": "50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"
                 }
             ]
         },
@@ -124,7 +129,7 @@
             "name": "python3-zipp",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"zipp==3.4.1\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"zipp\" --no-build-isolation"
             ],
             "sources": [
                 {
@@ -143,8 +148,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/94/40/c396b5b212533716949a4d295f91a4c100d51ba95ea9e2d96b6b0517e5a5/urllib3-1.26.5.tar.gz",
-                    "sha256": "a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+                    "url": "https://files.pythonhosted.org/packages/4f/5a/597ef5911cb8919efe4d86206aa8b2658616d676a7088f0825ca08bd7cb8/urllib3-1.26.6.tar.gz",
+                    "sha256": "f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
                 },
                 {
                     "type": "file",
@@ -201,8 +206,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/94/40/c396b5b212533716949a4d295f91a4c100d51ba95ea9e2d96b6b0517e5a5/urllib3-1.26.5.tar.gz",
-                    "sha256": "a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+                    "url": "https://files.pythonhosted.org/packages/4f/5a/597ef5911cb8919efe4d86206aa8b2658616d676a7088f0825ca08bd7cb8/urllib3-1.26.6.tar.gz",
+                    "sha256": "f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
                 },
                 {
                     "type": "file",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,13 +3,13 @@ toml
 setuptools-scm
 
 # qutebrowser/requirements.txt
-colorama==0.4.4
-importlib-resources==5.1.2; python_version<"3.9"
-Jinja2==2.11.3
-MarkupSafe==1.1.1
-PyYAML==5.4.1
-typing-extensions==3.7.4.3
-zipp==3.4.1
+colorama
+importlib-resources; python_version<"3.9"
+Jinja2
+MarkupSafe
+PyYAML
+typing-extensions
+zipp
 
 # TODO: add nacl
 # userscripts/qute-keepassxc


### PR DESCRIPTION
Initial work to automate updates with `flatpak-extenal-data-checker`.  
With this, update pull requests will be opened by flathubbot once a day.  
Automatic merging of PRs with successful CI builds was disabled.

This is very partial, doesn't handle:
* The `python-dependencies.json` module that was generated from requirements.txt with `flatpak-pip-generator`.
* Updates to qutebrowser itself as `python-dependencies.json` is also updated manually when a new version of qutebrowser is tagged. Automating `python-dependencies.json` update will help decouple those two and enable the checker for qutebrowser.
* Cargo modules as their `*-cargo-sources.json` were generated with `flatpak-cargo-generator.py`.
* Test related modules, though I'm not convinced that we should use Flathub's infrastructure for running tests.
* QtWebEngine module, the base app should be updated, and our module should be dropped.
* SIP, the v6.x.x PR should be merged first.

For the next step and completing the automation, there are two ways to go about it:
1. Wait for `flatpak-builder-tools` support in `f-e-d-c`.
2. Create a GitHub Action with `flatpak-builder-tools` to run the module generators.  
Conflicting with flathubbot PRs is a possibility, but ATM it's we can't disable these PRs.

In preparation for automating `python-dependencies.json`, Python module versions are not being forced now in `requirements.txt`. Rolling distro like Arch Linux don't seem to a problem with the latest module versions, and this change simplify updates.