### PR TITLE
Revert "python-dependencies: add f-e-d-c"

### DIFF
--- a/python-dependencies.json
+++ b/python-dependencies.json
@@ -13,11 +13,7 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz",
-                    "sha256": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "toml"
-                    }
+                    "sha256": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
                 }
             ]
         },
@@ -31,11 +27,7 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/57/38/930b1241372a9f266a7df2b184fb9d4f497c2cef2e016b014f82f541fe7c/setuptools_scm-6.0.1.tar.gz",
-                    "sha256": "d1925a69cb07e9b29416a275b9fadb009a23c148ace905b2fb220649a6c18e92",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "setuptools_scm"
-                    }
+                    "sha256": "d1925a69cb07e9b29416a275b9fadb009a23c148ace905b2fb220649a6c18e92"
                 }
             ]
         },
@@ -49,11 +41,7 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/1f/bb/5d3246097ab77fa083a61bd8d3d527b7ae063c7d8e8671b1cf8c4ec10cbe/colorama-0.4.4.tar.gz",
-                    "sha256": "5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "colorama"
-                    }
+                    "sha256": "5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"
                 }
             ]
         },
@@ -67,20 +55,12 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/38/f9/4fa6df2753ded1bcc1ce2fdd8046f78bd240ff7647f5c9bcf547c0df77e3/zipp-3.4.1.tar.gz",
-                    "sha256": "3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "zipp"
-                    }
+                    "sha256": "3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/7e/6c/2077c481c94e7a75e0678a41cb4e2a7916ac215e7a7677c5839513122d24/importlib_resources-5.1.4.tar.gz",
-                    "sha256": "54161657e8ffc76596c4ede7080ca68cb02962a2e074a2586b695a93a925d36e",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "importlib_resources"
-                    }
+                    "sha256": "54161657e8ffc76596c4ede7080ca68cb02962a2e074a2586b695a93a925d36e"
                 }
             ]
         },
@@ -94,20 +74,12 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/bf/10/ff66fea6d1788c458663a84d88787bae15d45daa16f6b3ef33322a51fc7e/MarkupSafe-2.0.1.tar.gz",
-                    "sha256": "594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "MarkupSafe"
-                    }
+                    "sha256": "594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/39/11/8076571afd97303dfeb6e466f27187ca4970918d4b36d5326725514d3ed3/Jinja2-3.0.1.tar.gz",
-                    "sha256": "703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "Jinja2"
-                    }
+                    "sha256": "703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4"
                 }
             ]
         },
@@ -121,11 +93,7 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/bf/10/ff66fea6d1788c458663a84d88787bae15d45daa16f6b3ef33322a51fc7e/MarkupSafe-2.0.1.tar.gz",
-                    "sha256": "594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "MarkupSafe"
-                    }
+                    "sha256": "594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"
                 }
             ]
         },
@@ -139,11 +107,7 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/a0/a4/d63f2d7597e1a4b55aa3b4d6c5b029991d3b824b5bd331af8d4ab1ed687d/PyYAML-5.4.1.tar.gz",
-                    "sha256": "607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "PyYAML"
-                    }
+                    "sha256": "607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"
                 }
             ]
         },
@@ -157,11 +121,7 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/aa/55/62e2d4934c282a60b4243a950c9dbfa01ae7cac0e8d6c0b5315b87432c81/typing_extensions-3.10.0.0.tar.gz",
-                    "sha256": "50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "typing_extensions"
-                    }
+                    "sha256": "50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"
                 }
             ]
         },
@@ -175,11 +135,7 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/38/f9/4fa6df2753ded1bcc1ce2fdd8046f78bd240ff7647f5c9bcf547c0df77e3/zipp-3.4.1.tar.gz",
-                    "sha256": "3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "zipp"
-                    }
+                    "sha256": "3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76"
                 }
             ]
         },
@@ -193,47 +149,27 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/4f/5a/597ef5911cb8919efe4d86206aa8b2658616d676a7088f0825ca08bd7cb8/urllib3-1.26.6.tar.gz",
-                    "sha256": "f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "urllib3"
-                    }
+                    "sha256": "f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/ea/b7/e0e3c1c467636186c39925827be42f16fee389dc404ac29e930e9136be70/idna-2.10.tar.gz",
-                    "sha256": "b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "idna"
-                    }
+                    "sha256": "b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/ee/2d/9cdc2b527e127b4c9db64b86647d567985940ac3698eeabc7ffaccb4ea61/chardet-4.0.0.tar.gz",
-                    "sha256": "0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "chardet"
-                    }
+                    "sha256": "0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/6d/78/f8db8d57f520a54f0b8a438319c342c61c22759d8f9a1cd2e2180b5e5ea9/certifi-2021.5.30.tar.gz",
-                    "sha256": "2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "certifi"
-                    }
+                    "sha256": "2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/6b/47/c14abc08432ab22dc18b9892252efaf005ab44066de871e72a38d6af464b/requests-2.25.1.tar.gz",
-                    "sha256": "27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "requests"
-                    }
+                    "sha256": "27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"
                 }
             ]
         },
@@ -247,29 +183,17 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/c8/3f/e71d92e90771ac2d69986aa0e81cf0dfda6271e8483698f4847b861dd449/soupsieve-2.2.1.tar.gz",
-                    "sha256": "052774848f448cf19c7e959adf5566904d525f33a3f8b6ba6f6f8f26ec7de0cc",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "soupsieve"
-                    }
+                    "sha256": "052774848f448cf19c7e959adf5566904d525f33a3f8b6ba6f6f8f26ec7de0cc"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/6b/c3/d31704ae558dcca862e4ee8e8388f357af6c9d9acb0cad4ba0fbbd350d9a/beautifulsoup4-4.9.3.tar.gz",
-                    "sha256": "84729e322ad1d5b4d25f805bfa05b902dd96450f43842c4e99067d5e1369eb25",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "beautifulsoup4"
-                    }
+                    "sha256": "84729e322ad1d5b4d25f805bfa05b902dd96450f43842c4e99067d5e1369eb25"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/10/ed/7e8b97591f6f456174139ec089c769f89a94a1a4025fe967691de971f314/bs4-0.0.1.tar.gz",
-                    "sha256": "36ecea1fd7cc5c0c6e4a1ff075df26d50da647b75376626cc186e2212886dd3a",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "bs4"
-                    }
+                    "sha256": "36ecea1fd7cc5c0c6e4a1ff075df26d50da647b75376626cc186e2212886dd3a"
                 }
             ]
         },
@@ -283,74 +207,42 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/4f/5a/597ef5911cb8919efe4d86206aa8b2658616d676a7088f0825ca08bd7cb8/urllib3-1.26.6.tar.gz",
-                    "sha256": "f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "urllib3"
-                    }
+                    "sha256": "f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/50/5c/d32aeed5c91e7970ee6ab8316c08d911c1d6044929408f6bbbcc763f8019/requests-file-1.5.1.tar.gz",
-                    "sha256": "07d74208d3389d01c38ab89ef403af0cfec63957d53a0081d8eca738d0247d8e",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "requests-file"
-                    }
+                    "sha256": "07d74208d3389d01c38ab89ef403af0cfec63957d53a0081d8eca738d0247d8e"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/ea/b7/e0e3c1c467636186c39925827be42f16fee389dc404ac29e930e9136be70/idna-2.10.tar.gz",
-                    "sha256": "b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "idna"
-                    }
+                    "sha256": "b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/ee/2d/9cdc2b527e127b4c9db64b86647d567985940ac3698eeabc7ffaccb4ea61/chardet-4.0.0.tar.gz",
-                    "sha256": "0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "chardet"
-                    }
+                    "sha256": "0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/6d/78/f8db8d57f520a54f0b8a438319c342c61c22759d8f9a1cd2e2180b5e5ea9/certifi-2021.5.30.tar.gz",
-                    "sha256": "2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "certifi"
-                    }
+                    "sha256": "2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/6b/47/c14abc08432ab22dc18b9892252efaf005ab44066de871e72a38d6af464b/requests-2.25.1.tar.gz",
-                    "sha256": "27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "requests"
-                    }
+                    "sha256": "27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/14/ec/6ee2168387ce0154632f856d5cc5592328e9cf93127c5c9aeca92c8c16cb/filelock-3.0.12.tar.gz",
-                    "sha256": "18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "filelock"
-                    }
+                    "sha256": "18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/42/9c/0340ebfabfbbb3a2868eaa1039479688ca52e1d7f433df4fae638941377f/tldextract-3.1.0.tar.gz",
-                    "sha256": "cfae9bc8bda37c3e8c7c8639711ad20e95dc85b207a256b60b0b23d7ff5540ea",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "tldextract"
-                    }
+                    "sha256": "cfae9bc8bda37c3e8c7c8639711ad20e95dc85b207a256b60b0b23d7ff5540ea"
                 }
             ]
         },
@@ -364,11 +256,7 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/a7/2c/4c64579f847bd5d539803c8b909e54ba087a79d01bb3aba433a95879a6c5/pyperclip-1.8.2.tar.gz",
-                    "sha256": "105254a8b04934f0bc84e9c24eb360a591aaf6535c9def5f29d92af107a9bf57",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "pyperclip"
-                    }
+                    "sha256": "105254a8b04934f0bc84e9c24eb360a591aaf6535c9def5f29d92af107a9bf57"
                 }
             ]
         },
@@ -382,83 +270,47 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/be/ed/5bbc91f03fa4c839c4c7360375da77f9659af5f7086b7a7bdda65771c8e0/python-dateutil-2.8.1.tar.gz",
-                    "sha256": "73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "python-dateutil"
-                    }
+                    "sha256": "73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/0f/86/e19659527668d70be91d0369aeaa055b4eb396b0f387a4f92293a20035bd/pycparser-2.20.tar.gz",
-                    "sha256": "2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "pycparser"
-                    }
+                    "sha256": "2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/e5/21/a2e4517e3d216f0051687eea3d3317557bde68736f038a3b105ac3809247/lxml-4.6.3.tar.gz",
-                    "sha256": "39b78571b3b30645ac77b95f7c69d1bffc4cf8c3b157c435a34da72e78c82468",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "lxml"
-                    }
+                    "sha256": "39b78571b3b30645ac77b95f7c69d1bffc4cf8c3b157c435a34da72e78c82468"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/45/0b/38b06fd9b92dc2b68d58b75f900e97884c45bedd2ff83203d933cf5851c9/future-0.18.2.tar.gz",
-                    "sha256": "b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "future"
-                    }
+                    "sha256": "b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/a8/20/025f59f929bbcaa579704f443a438135918484fffaacfaddba776b374563/cffi-1.14.5.tar.gz",
-                    "sha256": "fd78e5fee591709f32ef6edb9a015b4aa1a5022598e36227500c8f4e02328d9c",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "cffi"
-                    }
+                    "sha256": "fd78e5fee591709f32ef6edb9a015b4aa1a5022598e36227500c8f4e02328d9c"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/74/fd/d78e003a79c453e8454197092fce9d1c6099445b7e7da0b04eb4fe1dbab7/argon2-cffi-20.1.0.tar.gz",
-                    "sha256": "d8029b2d3e4b4cea770e9e5a0104dd8fa185c1724a0f01528ae4826a6d25f97d",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "argon2"
-                    }
+                    "sha256": "d8029b2d3e4b4cea770e9e5a0104dd8fa185c1724a0f01528ae4826a6d25f97d"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/82/e2/a0f9f5452a59bafaa3420585f22b58a8566c4717a88c139af2276bb5695d/pycryptodomex-3.10.1.tar.gz",
-                    "sha256": "541cd3e3e252fb19a7b48f420b798b53483302b7fe4d9954c947605d0a263d62",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "pycryptodomex"
-                    }
+                    "sha256": "541cd3e3e252fb19a7b48f420b798b53483302b7fe4d9954c947605d0a263d62"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/30/2f/e2e6bad1b80f744cf5c2a6d622e3dee698b43e6c040f980ae0ac0edd5e54/construct-2.10.54.tar.gz",
-                    "sha256": "3c130a67f05610557dd1b27e062a7165f92b517f9ed50db880ebe068696fd712",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "construct"
-                    }
+                    "sha256": "3c130a67f05610557dd1b27e062a7165f92b517f9ed50db880ebe068696fd712"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/f1/08/b4b8f7bce23190ed4f34f4d9cf4f75f8a255f4f4c378296daf4b7027d2cb/pykeepass-4.0.1.tar.gz",
-                    "sha256": "eaa2a016c15a81beb6e253a8cb1fe64738b5fb4a28389dcdba621ea538dd814b",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "pykeepass"
-                    }
+                    "sha256": "eaa2a016c15a81beb6e253a8cb1fe64738b5fb4a28389dcdba621ea538dd814b"
                 }
             ]
         },
@@ -472,38 +324,22 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/ee/2d/9cdc2b527e127b4c9db64b86647d567985940ac3698eeabc7ffaccb4ea61/chardet-4.0.0.tar.gz",
-                    "sha256": "0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "chardet"
-                    }
+                    "sha256": "0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/e5/21/a2e4517e3d216f0051687eea3d3317557bde68736f038a3b105ac3809247/lxml-4.6.3.tar.gz",
-                    "sha256": "39b78571b3b30645ac77b95f7c69d1bffc4cf8c3b157c435a34da72e78c82468",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "lxml"
-                    }
+                    "sha256": "39b78571b3b30645ac77b95f7c69d1bffc4cf8c3b157c435a34da72e78c82468"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz",
-                    "sha256": "49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "docopt"
-                    }
+                    "sha256": "49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
                 },
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/ad/2d/bb6c9b381e6b6a432aa2ffa8f4afdb2204f1ff97cfcc0766a5b7683fec43/breadability-0.1.20.tar.gz",
-                    "sha256": "f1a7fdad1e58e295df80954879143824c706bbfb1826cdf4b1d15de1a86afe99",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "breadability"
-                    }
+                    "sha256": "f1a7fdad1e58e295df80954879143824c706bbfb1826cdf4b1d15de1a86afe99"
                 }
             ]
         },
@@ -517,11 +353,7 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/26/70/6f8750066255d4d2b82b813dd2550e0bd2bee99d026d14088a7b977cd0fc/readability-0.3.1.tar.gz",
-                    "sha256": "f9030df8bc31aad45baffa9a2d9ce1fdd8051833e5b5bda3027df32fdec00fad",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "readability"
-                    }
+                    "sha256": "f9030df8bc31aad45baffa9a2d9ce1fdd8051833e5b5bda3027df32fdec00fad"
                 }
             ]
         },
@@ -535,11 +367,7 @@
                 {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/71/bd/ab05ffcbfe74dca704e860312e00c53ef690b1ddcb23be7a4d9ea4f40260/stem-1.8.0.tar.gz",
-                    "sha256": "a0b48ea6224e95f22aa34c0bc3415f0eb4667ddeae3dfb5e32a6920c185568c2",
-                    "x-checker-data": {
-                        "type": "pypi",
-                        "name": "stem"
-                    }
+                    "sha256": "a0b48ea6224e95f22aa34c0bc3415f0eb4667ddeae3dfb5e32a6920c185568c2"
                 }
             ]
         }


### PR DESCRIPTION
This reverts commit 38142c352b82c4f50b80effc3fc12d2340ad2722.

f-e-d-c was expected not to work correctly with the generated `python-dependencies.json`. Instead, we need to bake a GitHub Action that can run `flatpak-pip-generator`, or wait for such support in f-e-d-c.