### PR TITLE
PyQt6 Tests

### DIFF
--- a/org.qutebrowser.qutebrowser.yml
+++ b/org.qutebrowser.qutebrowser.yml
@@ -79,6 +79,10 @@ modules:
       - |
         export QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess
         export PYTHONPATH=.
+        # Flathub CI has XDG_RUNTIME_DIR mode bits set to 0755
+        if [ "$(stat --format=%04a $XDG_RUNTIME_DIR)" = "0755" ]; then
+          chmod -v 0700 $XDG_RUNTIME_DIR
+        fi
         # verbose output:  -v -s --no-qt-log
         # workaround for Flathub CI's inability to detect job failure and stopping it
         pytest --qute-backend=webengine || true

--- a/org.qutebrowser.qutebrowser.yml
+++ b/org.qutebrowser.qutebrowser.yml
@@ -86,7 +86,6 @@ modules:
       - type: git
         url: https://github.com/qutebrowser/qutebrowser.git
         branch: qt6-v2
-        commit: d860516c0686ce1b382d3bd0485952688b6095ad
     modules:
      #- pyqt-shared-module.json
       - asciidoc/asciidoc.json

--- a/org.qutebrowser.qutebrowser.yml
+++ b/org.qutebrowser.qutebrowser.yml
@@ -74,7 +74,7 @@ modules:
       - make --file misc/Makefile install PREFIX=/app
       - install -dm755 /app/{lib/ffmpeg,userscripts}
       - sed -i '/^Exec=qutebrowser/ s@=@=/app/bin/@' /app/share/applications/${FLATPAK_ID}.desktop
-    run-tests: false
+    run-tests: true
     test-commands:
       - |
         export QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess
@@ -100,4 +100,4 @@ modules:
       - pdfjs/pdfjs.json
       - flatpak-spawn-wrapper/flatpak-spawn-wrapper.json
       # TODO: f-e-d-c for tests
-      #- tests/tests-dependencies.json
+      - tests/tests-dependencies.json


### PR DESCRIPTION
Create PyQt6 test builds.  
For faster builds, userscripts supporting dependencies are disabled.