### PR TITLE
Faster builds part1

### DIFF
--- a/userscripts-dependencies/opendht/asio/asio.json
+++ b/userscripts-dependencies/opendht/asio/asio.json
@@ -1,5 +1,11 @@
 {
     "name": "asio",
+    "config-opts": [
+        "--with-boost=no"
+    ],
+    "make-args": [
+        "STANDALONE=1"
+    ],
     "sources": [
         {
             "type": "archive",

--- a/userscripts-dependencies/opendht/boost/boost.json
+++ b/userscripts-dependencies/opendht/boost/boost.json
@@ -3,7 +3,7 @@
     "buildsystem": "simple",
     "build-commands": [
         "./bootstrap.sh",
-        "./b2 variant=release debug-symbols=off --prefix=${FLATPAK_DEST} install"
+        "./b2 --with-chrono variant=release link=shared debug-symbols=off runtime-link=shared --prefix=${FLATPAK_DEST} install"
     ],
     "sources": [
         {

--- a/userscripts-dependencies/opendht/msgpack-cxx/msgpack-cxx.json
+++ b/userscripts-dependencies/opendht/msgpack-cxx/msgpack-cxx.json
@@ -5,8 +5,9 @@
         "-DCMAKE_BUILD_TYPE=Release",
         "-DBUILD_SHARED_LIBS=ON",
         "-DMSGPACK_CXX17=ON",
-        "-DMSGPACK_BUILD_EXAMPLES=OFF",
-        "-DMSGPACK_BUILD_TESTS=OFF"
+        "-DMSGPACK_USE_BOOST=OFF",
+        "-DMSGPACK_BUILD_TESTS=OFF",
+        "-DMSGPACK_BUILD_EXAMPLES=OFF"
     ],
     "sources": [
         {

--- a/userscripts-dependencies/opendht/opendht-python-install.patch
+++ b/userscripts-dependencies/opendht/opendht-python-install.patch
@@ -1,0 +1,13 @@
+diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
+index cc433d0..9a824be 100644
+--- a/python/CMakeLists.txt
++++ b/python/CMakeLists.txt
+@@ -8,7 +8,7 @@ add_custom_target(python ALL
+     COMMAND python3 setup.py build
+     DEPENDS opendht opendht_cpp.pxd opendht.pyx)
+ 
+-install(CODE "execute_process(COMMAND python3 setup.py install --root=\$ENV{DESTDIR}/ WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})")
++install(CODE "execute_process(COMMAND python3 setup.py install --skip-build --prefix=\$ENV{FLATPAK_DEST}/ --root=/  --optimize=1 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})")
+ if (OPENDHT_TOOLS)
+ 	install(PROGRAMS tools/dhtcluster.py DESTINATION ${CMAKE_INSTALL_BINDIR} RENAME dhtcluster)
+ endif()

--- a/userscripts-dependencies/opendht/opendht.json
+++ b/userscripts-dependencies/opendht/opendht.json
@@ -16,12 +16,15 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://github.com/savoirfairelinux/opendht/archive/2.3.2/opendht-2.3.2.tar.gz",
-            "sha256": "5a646e494ad9130f94beed18dc310242e896822cb9c6ffa9f2f06b9ef5c7fe8d",
+            "url": "https://github.com/savoirfairelinux/opendht/archive/c2415f38fa7d099414c1e3fc073d29419fc15ebb.tar.gz",
+            "sha256": "aa1105b7a0fd4c76838cde64f207cda2f82c621f96461d0d0fd5eb7ff50350c0",
             "x-checker-data": {
                 "type": "anitya",
                 "project-id": 12935,
                 "stable-only": true,
+                "versions": {
+                    ">": "2.3.2"
+                },
                 "url-template": "https://github.com/savoirfairelinux/opendht/archive/$version/opendht-$version.tar.gz"
             }
         },

--- a/userscripts-dependencies/opendht/opendht.json
+++ b/userscripts-dependencies/opendht/opendht.json
@@ -6,7 +6,6 @@
         "-DOPENDHT_LOG=OFF",
         "-DOPENDHT_PYTHON=ON",
         "-DOPENDHT_TOOLS=OFF",
-        "-DDOPENDHT_LTO=ON",
         "-DOPENDHT_PROXY_SERVER=ON",
         "-DOPENDHT_PUSH_NOTIFICATIONS=ON",
         "-DOPENDHT_PROXY_CLIENT=ON",
@@ -25,6 +24,10 @@
                 "stable-only": true,
                 "url-template": "https://github.com/savoirfairelinux/opendht/archive/$version/opendht-$version.tar.gz"
             }
+        },
+        {
+            "type": "patch",
+            "path": "opendht-python-install.patch"
         }
     ],
     "modules": [

--- a/userscripts-dependencies/opendht/restinio/fmt/fmt.json
+++ b/userscripts-dependencies/opendht/restinio/fmt/fmt.json
@@ -3,7 +3,9 @@
     "buildsystem": "cmake",
     "config-opts": [
         "-DCMAKE_BUILD_TYPE=None",
-        "-DBUILD_SHARED_LIBS=true"
+        "-DBUILD_SHARED_LIBS=ON",
+        "-DFMT_DOC=OFF",
+        "-DFMT_TEST=OFF"
     ],
     "sources": [
         {


### PR DESCRIPTION
Builds are too long. Disabling unnecessary boost libs, and fmt tests should get us better results.