### PR TITLE
Userscripts extension part1: Add extension mount point

### DIFF
--- a/org.qutebrowser.qutebrowser.yml
+++ b/org.qutebrowser.qutebrowser.yml
@@ -11,6 +11,11 @@ add-extensions:
     version: '21.08'
     add-ld-path: .
     no-autodownload: true
+  org.qutebrowser.qutebrowser.Userscripts:
+    directory: userscripts
+    version: 5.15-21.08
+    add-ld-path: lib
+    no-autodownload: true
 command: /app/bin/qutebrowser
 rename-icon: qutebrowser
 base: com.riverbankcomputing.PyQt.BaseApp
@@ -50,7 +55,7 @@ modules:
     build-commands:
       - python3 scripts/asciidoc2html.py
       - make --file misc/Makefile install PREFIX=/app
-      - install -dm755 /app/lib/ffmpeg
+      - install -dm755 /app/{lib/ffmpeg,userscripts}
       - sed -i '/^Exec=qutebrowser/ s@=@=/app/bin/@' /app/share/applications/${FLATPAK_ID}.desktop
     run-tests: false
     test-commands:


### PR DESCRIPTION
This is the first step in moving userscripts' dependencies and optionally
the userscripts themselves into a dedicated Flatpak extension.
In order to build the extension, we need the mount point available in a published build.