### PR TITLE
[beta] qutebrowser: Update to latest commit in qt6-v2 branch 850673bb

### DIFF
--- a/maturin-bin/maturin-bin-aarch64/maturin-bin-aarch64.json
+++ b/maturin-bin/maturin-bin-aarch64/maturin-bin-aarch64.json
@@ -10,8 +10,8 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/py3/m/maturin/maturin-0.12.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
-            "sha256": "0215a75ef14a982128d2a66ece5471171648f0477662970846082e107a7ec8fe",
+            "url": "https://files.pythonhosted.org/packages/py3/m/maturin/maturin-0.12.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+            "sha256": "97756ad5ff113478de237b029add91def0a40af0dc5e120c25e1595addd9c151",
             "x-checker-data": {
                 "type": "anitya",
                 "project-id": 42653,

--- a/maturin-bin/maturin-bin-x86_64/maturin-bin-x86_64.json
+++ b/maturin-bin/maturin-bin-x86_64/maturin-bin-x86_64.json
@@ -10,8 +10,8 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/py3/m/maturin/maturin-0.12.15-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl",
-            "sha256": "31527eeebb3c6a14cd856cef29ce8d52de650603e09e1a7ca41251e4e6404114",
+            "url": "https://files.pythonhosted.org/packages/py3/m/maturin/maturin-0.12.16-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl",
+            "sha256": "9ce67a844d63d1ba8cdcf903ee2e6e0b21c0b0461b97c8737751d74002ded4c4",
             "x-checker-data": {
                 "type": "anitya",
                 "project-id": 42653,

--- a/org.qutebrowser.qutebrowser.yml
+++ b/org.qutebrowser.qutebrowser.yml
@@ -96,8 +96,8 @@ modules:
       #   available in the sdk but not in the runtime
       - python-pygments/python-pygments.json
       - python-pyyaml/python-pyyaml.json
-      #- python-adblock/python-adblock.json
-      - python-adblock-bin/python-adblock-bin.json
+      - python-adblock/python-adblock.json
+      #- python-adblock-bin/python-adblock-bin.json
       - pdfjs/pdfjs.json
       - flatpak-spawn-wrapper/flatpak-spawn-wrapper.json
       # TODO: f-e-d-c for tests

--- a/org.qutebrowser.qutebrowser.yml
+++ b/org.qutebrowser.qutebrowser.yml
@@ -86,7 +86,7 @@ modules:
       - type: git
         url: https://github.com/qutebrowser/qutebrowser.git
         branch: qt6-v2
-        commit: 6fae468b6f83d35557ed216ac104ec3e79f39442
+        commit: 4d04619670967347220ee25e3e6c4172558c71c6
     modules:
      #- pyqt-shared-module.json
       - asciidoc/asciidoc.json

--- a/pdfjs/pdfjs.json
+++ b/pdfjs/pdfjs.json
@@ -10,8 +10,8 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://github.com/mozilla/pdf.js/releases/download/v2.13.216/pdfjs-2.13.216-dist.zip",
-            "sha256": "b87723ec4f9250fabddfae6e715096bd77e864e2d43015365c657def561c2b42",
+            "url": "https://github.com/mozilla/pdf.js/releases/download/v2.14.305/pdfjs-2.14.305-dist.zip",
+            "sha256": "1929a00d26d7cd631033ab5a06dcd7d6c283b7d3b06c76083fb840bd1e014896",
             "x-checker-data": {
                 "type": "json",
                 "url": "https://api.github.com/repos/mozilla/pdf.js/releases",

--- a/update.sh
+++ b/update.sh
@@ -8,19 +8,19 @@ _TOOLSDIR=$PWD/tools
 
 flatpak-external-data-checker --edit-only ${_FPID}.yml
 
-#for _mod in python-adblock; do
-#  (
-#    cd ${_mod%:*}
-#    case $_mod in
-#      *:*Cargo.lock)
-#        ${_TOOLSDIR}/cargo-updater $(basename ${_mod%:*}) ${_mod#*:}
-#        ;;
-#      *)
-#        ${_TOOLSDIR}/cargo-updater $(basename ${_mod%:*})
-#        ;;
-#    esac
-#  )
-#done
+for _mod in python-adblock; do
+  (
+    cd ${_mod%:*}
+    case $_mod in
+      *:*Cargo.lock)
+        ${_TOOLSDIR}/cargo-updater $(basename ${_mod%:*}) ${_mod#*:}
+        ;;
+      *)
+        ${_TOOLSDIR}/cargo-updater $(basename ${_mod%:*})
+        ;;
+    esac
+  )
+done
 
 # python modules with multiple dependencies and have a requirements.txt file
 #for _mod in tests; do


### PR DESCRIPTION
- qutebrowser: Bump qt6-v2 branch commit to 850673bb
- pdfjs: Update to 2.14.305
- python-adblock: Switch back to build from source
- maturin-bin: Update to 0.12.16