### PR TITLE
Update pdfjs to 2.15.349

### DIFF
--- a/maturin-bin/maturin-bin-aarch64/maturin-bin-aarch64.json
+++ b/maturin-bin/maturin-bin-aarch64/maturin-bin-aarch64.json
@@ -10,8 +10,8 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/py3/m/maturin/maturin-0.12.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl",
-            "sha256": "79a26abbbbdb78958894837663e18e39c36635bcc0674ed40217b3519c488115",
+            "url": "https://files.pythonhosted.org/packages/py3/m/maturin/maturin-0.13.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl",
+            "sha256": "d6086970da37bd8a0d06eb9c31197c25fbb4c82257b9a385786ce54e8b05071d",
             "x-checker-data": {
                 "type": "anitya",
                 "project-id": 42653,

--- a/maturin-bin/maturin-bin-x86_64/maturin-bin-x86_64.json
+++ b/maturin-bin/maturin-bin-x86_64/maturin-bin-x86_64.json
@@ -10,8 +10,8 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/py3/m/maturin/maturin-0.12.20-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl",
-            "sha256": "ac3b6ae80adfd2ddb581d78ac695abfeb1e222bf122f0f8cb04ab2bae47046b1",
+            "url": "https://files.pythonhosted.org/packages/py3/m/maturin/maturin-0.13.1-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl",
+            "sha256": "7a60f5c1040985ef56b254f2c32f71dbf4ac11db0cc7cf80f0aeca6bd24cf324",
             "x-checker-data": {
                 "type": "anitya",
                 "project-id": 42653,

--- a/org.qutebrowser.qutebrowser.yml
+++ b/org.qutebrowser.qutebrowser.yml
@@ -67,6 +67,8 @@ cleanup-commands:
   - rm -vrf ${FLATPAK_DEST}/lib/python*/site-packages/toml-*.dist-info
   - rm -vrf ${FLATPAK_DEST}/lib/python*/site-packages/tomli
   - rm -vrf ${FLATPAK_DEST}/lib/python*/site-packages/tomli-*.dist-info
+  - rm -vrf ${FLATPAK_DEST}/lib/python*/site-packages/typing_extensions-*.dist-info
+  - rm -vrf ${FLATPAK_DEST}/lib/python*/site-packages/typing_extensions.py
 modules:
   - name: qutebrowser
     buildsystem: simple

--- a/pdfjs/pdfjs.json
+++ b/pdfjs/pdfjs.json
@@ -10,8 +10,8 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://github.com/mozilla/pdf.js/releases/download/v2.14.305/pdfjs-2.14.305-dist.zip",
-            "sha256": "1929a00d26d7cd631033ab5a06dcd7d6c283b7d3b06c76083fb840bd1e014896",
+            "url": "https://github.com/mozilla/pdf.js/releases/download/v2.15.349/pdfjs-2.15.349-dist.zip",
+            "sha256": "7242189907fda24e1250c2d395a219f6cff93e51ff9c1fd13123d93e9cd523b0",
             "x-checker-data": {
                 "is-important": true,
                 "type": "json",

--- a/python-adblock/python-adblock.json
+++ b/python-adblock/python-adblock.json
@@ -9,7 +9,7 @@
     "buildsystem": "simple",
     "build-commands": [
         "cargo --offline fetch --manifest-path Cargo.toml --verbose",
-        "maturin build --release --strip --cargo-extra-args='--offline'",
+        "maturin build --release --strip --offline",
         "pip3 install --exists-action=i --no-index --find-links=file://${PWD}/target/wheels --prefix=${FLATPAK_DEST} adblock --no-build-isolation"
     ],
     "sources": [


### PR DESCRIPTION
Also bump maturin to 0.13.1 and drop the now unneeded `--cargo-extra-args` maturin option.

Supersedes #240