### PR TITLE
CI: Disable scheduled beta update check

### DIFF
--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -1,7 +1,7 @@
 name: Update beta
 on:
-  schedule:
-    - cron: '3/40 21-23 * * *'
+# schedule:
+#   - cron: '3/40 21-23 * * *'
   workflow_dispatch: {}
 jobs:
   flatpak-external-data-checker:


### PR DESCRIPTION
For the meantime, keep only the manually triggered check.