### PR TITLE
Drop org.kde.* own-name

### DIFF
--- a/org.qutebrowser.qutebrowser.yml
+++ b/org.qutebrowser.qutebrowser.yml
@@ -42,7 +42,6 @@ finish-args:
   - --filesystem=xdg-videos
   - --filesystem=xdg-run/pipewire-0:ro
   - --filesystem=/run/.heim_org.h5l.kcm-socket
-  - --own-name=org.kde.*
   - --own-name=org.mpris.MediaPlayer2.qutebrowser.*
   - --share=ipc
   - --share=network


### PR DESCRIPTION
This is no longer required with any supported runtimes, the issue was fixed in Qt

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement

https://github.com/flathub/flatpak-builder-lint/issues/ 66#issuecomment-1386033025


Might require to update to 22.08 runtime before.