### PR TITLE
Disable x-checker as no maintainer is active

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,5 @@
 {
     "automerge-flathubbot-prs": false,
-    "disable-external-data-checker": false,
+    "disable-external-data-checker": true,
     "require-important-update": true
 }


### PR DESCRIPTION
Last activity by the maintainer @tinywrkb was 8 months ago on `master` and 9 months ago on `beta` https://github.com/flathub/org.qutebrowser.qutebrowser/commit/5e79dd19551b63031d2dfb57cfef847d9ea1c2d5 https://github.com/flathub/org.qutebrowser.qutebrowser/commit/45a96647d5324b2e552317082b15a1ca4a4d121f

Both branches are on EOL runtimes with outdated version of application.

The x-checker is spamming with new PRs. So disable it until a maintainer becomes active again.

Feel free to re-enable it/ping me for any help.